### PR TITLE
Add init command

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,10 +1,11 @@
 let dev = require('./dev')
 let generate = require('./generate')
 let help = require('./help')
+let init = require('./init')
 let newProj = require('./new')
 let version = require('./version')
 let commands = [
-  dev, generate, help, newProj, version
+  dev, generate, help, init, newProj, version
 ]
 
 let helper = require('../helper')

--- a/src/commands/init/action.js
+++ b/src/commands/init/action.js
@@ -34,7 +34,6 @@ enhance/arc-plugin-enhance
   if (existsSync(pkgFilePath)) {
     const pkgFile = require(join(dest, 'package.json'))
     pkgFile.scripts.enhance = 'enhance'
-    pkgFile.scripts.start = 'npx enhance dev'
     pkgFile.devDependencies['@enhance/cli'] = 'latest'
     pkgFile.devDependencies['@enhance/types'] = 'latest'
     pkgFile.dependencies['@enhance/arc-plugin-enhance'] = 'latest'

--- a/src/commands/init/action.js
+++ b/src/commands/init/action.js
@@ -1,0 +1,74 @@
+module.exports = async function (params) {
+  let { existsSync, writeFileSync } = require('fs')
+  let { join, resolve } = require('path')
+
+  let utils = require('../../lib')
+  let { npmCommands: { initialInstall } } = utils
+  let error = require('./errors')(params, utils)
+  let _inventory = require('@architect/inventory')
+  let c = require('@colors/colors/safe')
+
+  let dest = resolve('.')
+
+  // Error out if folder already exists and it has an arc project already
+  if (existsSync(dest)) {
+    let inventory = await _inventory({ cwd: dest })
+    let invalid = inventory.inv._project.manifest
+    if (invalid) return error('project_found')
+  }
+
+  // write arc file
+  writeFileSync(join(dest, '.arc'),
+    `@app
+enhance-app
+
+@static
+prune true
+
+@plugins
+enhance/arc-plugin-enhance
+`
+  )
+
+  const pkgFilePath = join(dest, 'package.json')
+  if (existsSync(pkgFilePath)) {
+    const pkgFile = require(join(dest, 'package.json'))
+    pkgFile.scripts.enhance = 'enhance'
+    pkgFile.scripts.start = 'npx enhance dev'
+    pkgFile.devDependencies['@enhance/cli'] = 'latest'
+    pkgFile.devDependencies['@enhance/types'] = 'latest'
+    pkgFile.dependencies['@enhance/arc-plugin-enhance'] = 'latest'
+
+    writeFileSync(
+      pkgFilePath,
+      JSON.stringify(pkgFile, null, 2),
+    )
+  }
+  else {
+    writeFileSync(
+      pkgFilePath,
+      `{
+  "name": "enhance-app",
+  "version": "0.0.1",
+  "scripts": {
+    "start": "npx enhance dev",
+    "enhance": "enhance"
+  },
+  "devDependencies": {
+    "@enhance/cli": "latest",
+    "@enhance/types": "latest"
+  },
+  "dependencies": {
+    "@enhance/arc-plugin-enhance": "latest"
+  }
+}
+`
+    )
+  }
+
+  // Need to install enhance/arc-plugin-enhance or 💥
+  await initialInstall(params, dest)
+
+  // Success message
+  console.error(`Project successfully initialized! To get started run: ${c.bold(c.green(`npx enhance dev`))}`)
+}

--- a/src/commands/init/errors.js
+++ b/src/commands/init/errors.js
@@ -1,0 +1,15 @@
+module.exports = function error (params, utils) {
+  return function (err) {
+    let { lang } = params
+    let { backtickify, runtimes } = utils
+    let errors = {
+      en: {
+        no_path: 'Project path not found, please run with -p or --path',
+        project_found: 'Existing Enhance app already found in this directory',
+        invalid_appname: `Invalid app name`,
+        invalid_runtime: `Function runtime must be one of: ${backtickify(runtimes)}`,
+      }
+    }
+    return Error(errors[lang][err])
+  }
+}

--- a/src/commands/init/index.js
+++ b/src/commands/init/index.js
@@ -1,0 +1,21 @@
+let names = { en: [ 'init' ] }
+let action = require('./action')
+
+module.exports = {
+  names,
+  action,
+  help: () => {
+    return {
+      en: {
+        usage: [ 'init' ],
+        description: 'Initialize a new empty Enhance project',
+        examples: [
+          {
+            name: 'Create a new project in the current folder',
+            example: 'npx @enhance/cli init',
+          },
+        ]
+      },
+    }
+  }
+}

--- a/src/commands/new/index.js
+++ b/src/commands/new/index.js
@@ -1,4 +1,4 @@
-let names = { en: [ 'new', 'init' ] }
+let names = { en: [ 'new' ] }
 let action = require('./action')
 
 module.exports = {
@@ -21,16 +21,12 @@ module.exports = {
         },
         examples: [
           {
-            name: 'Create a new project in the current folder',
-            example: 'npx enhance new',
-          },
-          {
             name: 'Create a new project in the ./my-proj folder',
-            example: 'npx enhance new my-proj',
+            example: 'npx @enhance/cli new my-proj',
           },
           {
-            name: 'Create a new project with the name my-app',
-            example: 'npx enhance new project -n my-app',
+            name: 'Create a new project in the ./my-proj folder with the name my-app',
+            example: 'npx @enhance/cli new my-proj -n my-app',
           },
         ]
       },


### PR DESCRIPTION
This removes the alias `init` of `new` and gives it new functionality.

When `npx @enhance/cli init` is run it will:

- check to see if the current folder has a .arc file. If so it errors out.
- creates a new minimal .arc file
- checks for package.json.
- if it exists it updates the current package.json
- if not, it creates a minimal package.json

The one thing this change does not do is create an app folder with `app/pages/index.html`.