### PR TITLE
Add a link to the cribsheet in the console output

### DIFF
--- a/src/commands/dev/index.js
+++ b/src/commands/dev/index.js
@@ -55,6 +55,12 @@ async function action (params) {
           let specified = prefs?.http || n(port) || n(ARC_HTTP_PORT) || n(PORT)
           let link = c.green(c.bold(c.underline(`http://localhost:${specified}\n`)))
           process.stdout.write(link)
+          process.stdout.write('\n')
+
+          let cribsheetMsg = c.white('View the preconfigured Enhance utility classes')
+          let cribsheetLink = c.green(c.bold(c.underline(`http://localhost:${specified}/_styleguide/cribsheet\n`)))
+          console.error(`${ready} ${cribsheetMsg}`)
+          process.stdout.write(cribsheetLink)
         }
       }
       resolve()


### PR DESCRIPTION
Hello! I'm new to enhance and had a difficult time finding docs about the available preconfigured utility classes. I had actually given up on it for a day or two and was just looking through the `.enhance/generated.css` file to see what my options were.

I eventually found the `/_styleguide/cribsheet` link in the docs [here](https://enhance.dev/docs/enhance-styles/utility-classes#cribsheet) which is far nicer that what I was doing! :sweat_smile:

My initial thought was to ask if we could call attention to it better in the docs somehow, but then I thought, "Why not just output the link when you start the dev server?"

I have no opinions on the `View the preconfigured Enhance utility classes` message if you want something different. That was just the first thing I thought of.

I hope this makes the cribsheet easier to find for people new to Enhance. Let me know what y'all think!