### PR TITLE
bump sandbox to 7.1.0 to support mjs seed data loading in type:module projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@apidevtools/json-schema-ref-parser": "9.1.0",
     "@architect/inventory": "^4.0.5",
     "@architect/parser": "^7.0.1",
-    "@architect/sandbox": "^6.0.5",
+    "@architect/sandbox": "^7.1.0",
     "@architect/utils": "^4.0.6",
     "@colors/colors": "1.6.0",
     "@enhance/create": "^4.1.2",


### PR DESCRIPTION
I need this in my project pretty please 🙏 

Otherwise I get hit with the issues described here: https://github.com/architect/architect/issues/1512